### PR TITLE
Refactor sign up

### DIFF
--- a/frontend/src/components/app.js
+++ b/frontend/src/components/app.js
@@ -8,7 +8,8 @@ import "./main.css";
 
 import MainPage from "./main/main_page";
 import LoginFormContainer from "./session/login_form_container";
-import SignupFormContainer from "./session/signup_form_container";
+// import SignupFormContainer from "./session/signup_form_container";
+import SignUp from "./session/signUp";
 import ComponentLibrary from "./library/showcase";
 import { library } from "@fortawesome/fontawesome-svg-core";
 // import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -23,7 +24,8 @@ const App = () => (
       <AuthRoute exact path="/" component={MainPage} />
       <ProtectedRoute exact path="/components" component={ComponentLibrary} />
       <AuthRoute exact path="/login" component={LoginFormContainer} />
-      <AuthRoute exact path="/signup" component={SignupFormContainer} />
+      {/* <AuthRoute exact path="/signup" component={SignupFormContainer} /> */}
+      <AuthRoute exact path="/signup" component={SignUp} />
     </Switch>
   </div>
 );

--- a/frontend/src/components/session/formStepper.js
+++ b/frontend/src/components/session/formStepper.js
@@ -1,0 +1,198 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "@material-ui/core/styles";
+import Stepper from "@material-ui/core/Stepper";
+import Step from "@material-ui/core/Step";
+import StepLabel from "@material-ui/core/StepLabel";
+import Button from "@material-ui/core/Button";
+import Typography from "@material-ui/core/Typography";
+
+import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
+
+const muiTheme = createMuiTheme({
+  overrides: {
+    MuiStepIcon: {
+      root: {
+        "&$active": {
+          color: "rgb(33, 206, 153)"
+        },
+        "&$completed": {
+          color: "rgb(58, 230, 177)"
+        }
+      }
+    }
+  }
+});
+
+const styles = theme => ({
+  root: {
+    width: "90%"
+  },
+  button: {
+    marginRight: theme.spacing.unit,
+    backgroundColor: "rgb(33, 206, 153)",
+    "&:hover": {
+      backgroundColor: "rgb(28, 152, 114)"
+    }
+  },
+  instructions: {
+    marginTop: theme.spacing.unit,
+    marginBottom: theme.spacing.unit
+  }
+});
+
+function getSteps() {
+  return ["Account", "Basic Info", "Submit"];
+}
+
+function getStepContent(step) {
+  switch (step) {
+    case 0:
+      return "Account...";
+    case 1:
+      return "Your basic info...";
+    case 2:
+      return "Make sure it's all good to go...";
+    default:
+      return "Unknown step";
+  }
+}
+
+class HorizontalLinearStepper extends React.Component {
+  state = {
+    activeStep: 0,
+    skipped: new Set()
+  };
+
+  isStepOptional = step => step === 1;
+
+  handleNext = () => {
+    const { activeStep } = this.state;
+    let { skipped } = this.state;
+    if (this.isStepSkipped(activeStep)) {
+      skipped = new Set(skipped.values());
+      skipped.delete(activeStep);
+    }
+    this.setState({
+      activeStep: activeStep + 1,
+      skipped
+    });
+  };
+
+  handleBack = () => {
+    this.setState(state => ({
+      activeStep: state.activeStep - 1
+    }));
+  };
+
+  handleSkip = () => {
+    const { activeStep } = this.state;
+    if (!this.isStepOptional(activeStep)) {
+      // You probably want to guard against something like this,
+      // it should never occur unless someone's actively trying to break something.
+      throw new Error("You can't skip a step that isn't optional.");
+    }
+
+    this.setState(state => {
+      const skipped = new Set(state.skipped.values());
+      skipped.add(activeStep);
+      return {
+        activeStep: state.activeStep + 1,
+        skipped
+      };
+    });
+  };
+
+  handleReset = () => {
+    this.setState({
+      activeStep: 0
+    });
+  };
+
+  isStepSkipped(step) {
+    return this.state.skipped.has(step);
+  }
+
+  render() {
+    const { classes } = this.props;
+    const steps = getSteps();
+    const { activeStep } = this.state;
+
+    return (
+      <MuiThemeProvider theme={muiTheme}>
+        <div className={classes.root}>
+          <Stepper activeStep={activeStep}>
+            {steps.map((label, index) => {
+              const props = {};
+              const labelProps = {};
+              if (this.isStepOptional(index)) {
+                labelProps.optional = (
+                  <Typography variant="caption">Optional</Typography>
+                );
+              }
+              if (this.isStepSkipped(index)) {
+                props.completed = false;
+              }
+              return (
+                <Step key={label} {...props}>
+                  <StepLabel {...labelProps}>{label}</StepLabel>
+                </Step>
+              );
+            })}
+          </Stepper>
+          <div>
+            {activeStep === steps.length ? (
+              <div>
+                <Typography className={classes.instructions}>
+                  All steps completed - you&apos;re finished
+                </Typography>
+                <Button onClick={this.handleReset} className={classes.button}>
+                  Reset
+                </Button>
+              </div>
+            ) : (
+              <div>
+                <Typography className={classes.instructions}>
+                  {getStepContent(activeStep)}
+                </Typography>
+                <div>
+                  <Button
+                    disabled={activeStep === 0}
+                    onClick={this.handleBack}
+                    className={classes.button}
+                  >
+                    Back
+                  </Button>
+                  {this.isStepOptional(activeStep) && (
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      onClick={this.handleSkip}
+                      className={classes.button}
+                    >
+                      Skip
+                    </Button>
+                  )}
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={this.handleNext}
+                    className={classes.button}
+                  >
+                    {activeStep === steps.length - 1 ? "Finish" : "Next"}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </MuiThemeProvider>
+    );
+  }
+}
+
+HorizontalLinearStepper.propTypes = {
+  classes: PropTypes.object
+};
+
+export default withStyles(styles, { withTheme: true })(HorizontalLinearStepper);

--- a/frontend/src/components/session/formStepper.js
+++ b/frontend/src/components/session/formStepper.js
@@ -6,6 +6,7 @@ import Step from "@material-ui/core/Step";
 import StepLabel from "@material-ui/core/StepLabel";
 import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
+import SignUpForm from "./signup_form_container";
 
 import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
 
@@ -48,7 +49,7 @@ function getSteps() {
 function getStepContent(step) {
   switch (step) {
     case 0:
-      return "Account...";
+      return <SignUpForm />;
     case 1:
       return "Your basic info...";
     case 2:
@@ -152,9 +153,9 @@ class HorizontalLinearStepper extends React.Component {
               </div>
             ) : (
               <div>
-                <Typography className={classes.instructions}>
-                  {getStepContent(activeStep)}
-                </Typography>
+                {/* <Typography className={classes.instructions}> */}
+                {getStepContent(activeStep)}
+                {/* </Typography> */}
                 <div>
                   <Button
                     disabled={activeStep === 0}

--- a/frontend/src/components/session/formStepper.stories.js
+++ b/frontend/src/components/session/formStepper.stories.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import StoryRouter from "storybook-react-router";
+// import { action } from '@storybook/addon-actions';
+
+import FormStepper from "./formStepper";
+import Box from "../library/box";
+
+const stories = storiesOf("FormStepper", module);
+// allow react-router-dom Link access to StoryRouter
+stories.addDecorator(StoryRouter());
+
+stories.add("default", () => (
+  <Box>
+    <FormStepper />
+  </Box>
+));

--- a/frontend/src/components/session/signUp.js
+++ b/frontend/src/components/session/signUp.js
@@ -1,0 +1,10 @@
+import React from "react";
+import FormStepper from "./formStepper";
+
+export default function SignUp() {
+  return (
+    <div>
+      <FormStepper />
+    </div>
+  );
+}

--- a/frontend/src/components/session/signup_form.css
+++ b/frontend/src/components/session/signup_form.css
@@ -1,7 +1,7 @@
 .signup-container {
-  width: 85%;
+  /* width: 85%; */
   margin: auto;
-  margin-top: 50px;
+  /* margin-top: 50px; */
 }
 
 .signup-form-header {
@@ -53,11 +53,14 @@
 
 .signup-form-subheader {
   font-size: 26px;
-  margin-top: 10px;
+  margin-top: 30px;
 }
 
 .signup-form-inputs {
   padding: 10px;
+}
+.signup-form-input:focus {
+  border: 2px solid rgb(33, 206, 153);
 }
 
 .signup-form-inputs-row {
@@ -73,6 +76,6 @@
   line-height: 1.33;
   border-radius: 4px;
   color: #040d14;
-  border: 1px solid #b1bfc4;
+  border: 2px solid #b1bfc4;
   width: 100%;
 }

--- a/frontend/src/components/session/signup_form.js
+++ b/frontend/src/components/session/signup_form.js
@@ -59,14 +59,14 @@ class SignupForm extends React.Component {
     return (
       <div className="signup-container">
         <div className="signup-form-header">
-          <div className="signup-form-header-logo">
+          {/* <div className="signup-form-header-logo">
             <img
               src="https://d2ue93q3u507c2.cloudfront.net/assets/robinhood/images/logo.png"
               alt="Logo"
             />
-          </div>
+          </div> */}
 
-          <div className="signup-form-progress">
+          {/* <div className="signup-form-progress">
             <div className="signup-progress-text-container">
               <div className="signup-progress-text">Account</div>
               <div className="signup-progress-text">Basic Info</div>
@@ -78,7 +78,7 @@ class SignupForm extends React.Component {
             <div className="signup-progress-bar">
               <div className="signup-progress-bar-segment" />
             </div>
-          </div>
+          </div> */}
         </div>
 
         <div className="signup-form-container">


### PR DESCRIPTION
 > **PLEASE NOTE**: signUp.js is little more than a wrapper for FormStepper at this point. _However_, this was done in order to allow for future customization of the page without needing to go into FormStepper. For example, adding a sidebar or a footer to the form. This can be undone by simply removing this file and pointing the `/signup` route in `App.js` to `FormStepper` instead.

> _Much of the legacy code is left in as comments for documentation purposes. Feel free to delete it._

**Completed**
- Removed step tracker from signup and made into its own component
- Removed logo from signup, since already visible in the navigation bar
- Created a formStepper component using Material-UI library
- Pointed `/signup` route to new `signUp` component

**To do**
- move signupForm styles inside the component using styled-components
- give the formStepper button appropriate callback functions from signupForm so that click the next step does not reset state to null.

>formStepper relies heavily on Material-UI and its API documentation. Read the end of these notes for a very quick synopsis.

**formStepper API**

- Mui-Theme overrides
`const muiTheme = createMuiTheme({...` is where the Material UI theme override is taking place. This is done on top of `const styles = ...` because the `styles` API does not allow for overriding things like button states, only very limited and specific class instances. For more information visit [MUI API Docs](https://material-ui.com/customization/overrides/#overriding-with-classes).

- Styles constant
`const styles = { stylesObject }` works similarly to the way `Radium` did. It's built into Material-UI APIs. Allows for quick and easy style changes to pre-built components. Nothing fancy.

- getSteps
This function generates each step's label (given as a string). The order of the labels occurs in the same order that they do in the returned array. Theoretically, this can return more than just a string, like a JSX component, should the need arise.

`function getSteps() {
  return ["Account", "Basic Info", "Submit"];
}`

- getStepsContent
This function 'gets' the content for each step. This can, again, be almost anything. In this case, the first step is the signUpForm component. The other two are just strings

`function getStepContent(step) {
  switch (step) {
    case 0:
      return <SignUpForm />;
    case 1:
      return "Your basic info...";
    case 2:
      return "Make sure it's all good to go...";
    default:
      return "Unknown step";
  }
}`
