### PR TITLE
Fix login page inputs losing outline when hovered over

### DIFF
--- a/frontend/src/components/session/login_form.css
+++ b/frontend/src/components/session/login_form.css
@@ -70,7 +70,7 @@
 }
 
 .login-form-input:focus {
-  border: 1px solid #21ce99;
+  border: 1px solid #21ce99 !important;
   background-color: #fff;
 }
 

--- a/frontend/src/components/session/login_form.js
+++ b/frontend/src/components/session/login_form.js
@@ -90,7 +90,6 @@ class LoginForm extends React.Component {
               type="password"
               value={this.state.password}
               onChange={this.update("password")}
-              onClick={() => console.log("clicked")}
               required
             />
             </div>


### PR DESCRIPTION
Fixed issue on login page where input fields were losing green outline when hovered over.
Also removed a console.log from the login form that was accidentally left in for debugging.